### PR TITLE
Update docs styles for generated pages

### DIFF
--- a/docs/Deposit & Withdraw.md
+++ b/docs/Deposit & Withdraw.md
@@ -14,7 +14,7 @@ When recorded on the Qredo blockchain, a transaction is always linked to the und
 Summary of Steps
 ----------------
 
-For deposits, you can:  
+For deposits, you can:
   - [view deposit addresses](#view-deposit-addresses)
   - [copy an address](#copy-address)
   - [view deposit transactions](#view-transactions)
@@ -24,13 +24,13 @@ For withdrawals, a trade initiator can:
   - [create a transaction](#create-transaction)
   - [track progress](#track-progress) in different ways
 
-A custodian that is nominated can [approve a withdrawal](#approve-withdrawal) 
+A custodian that is nominated can [approve a withdrawal](#approve-withdrawal)
 
 View Deposit Addresses
 ----------------------
 
 The default fund and asset that you have set up includes a deposit address, which is the cryptocurrency wallet address that is linked to a Qredo fund. However, any
-fund that you create is linked to a deposit address. The address is securely created using the MPC protocol. 
+fund that you create is linked to a deposit address. The address is securely created using the MPC protocol.
 
 You are notified when money arrives at your address via an email.
 
@@ -38,13 +38,12 @@ You are notified when money arrives at your address via an email.
 
 ![coins](/doc-images/coins.png)
 
-![Ledger](/doc-images/ledger.png) 
+![Ledger](/doc-images/ledger.png)
 
 The following shows address entries in Asset view.
 
-|     |     |
+| Column Name | Description |
 | --- | --- |
-| **Column Name** | **Description** |
 | WALLET NAME | Name that is assigned to the wallet, which includes the name of the fund. |
 | FORMAT | Format of the wallet address. For example, for a Bitcoin address, this format is P2PKH. |
 | ADDRESS | The address string. |
@@ -65,9 +64,8 @@ In Ledger view, you can see deposit transactions to one or more funds that you a
 
 ![TX](/doc-images/TXibd.png)
 
-|     |     |
+| Column Name | Description |
 | --- | --- |
-| **Column Name** | **Description** |
 | TYPE | Type of transaction. For a deposit, the column name shows as deposit |
 | RECEIVED | Date and time in which the deposit transaction was received. |
 | TX | Amount deposited in to the account. |
@@ -83,49 +81,49 @@ If you do not have a withdrawal address, you need to create one before the trans
 
 ![coins](/doc-images/coins.png)
 
-![Ledger](/doc-images/ledger.png) 
+![Ledger](/doc-images/ledger.png)
 
 2. Click the **New TX** button. The Select Type window shows.
 
 ![startwithdraw](/doc-images/StartWithdrawR.png)
 
-3.  Choose the **Withdraw** option in Select Type.    
-4.  Click **Continue**. The Withdraw screen shows.  
+3.  Choose the **Withdraw** option in Select Type.
+4.  Click **Continue**. The Withdraw screen shows.
 5.  To set up a withdraw address on the fund, choose a fund from the **Fund** list and click the **Add Withdrawal Address** button. The Add Withdrawal Address screen shows.
 
 ![add withdrawal add](/doc-images/addwithadd.png)
 
 6.  To set up a withdraw address on an asset, choose an asset from the **Asset** list and click the **Add Withdrawal Address** button. The same screen appears.
-7.  In the Add Withdrawal Address screen, select the fund that you want to add the address to in **Source Fund**.    
-8.  Choose the asset type in **Asset**.    
-9.  Enter a name for the wallet in **Wallet Name**.   
+7.  In the Add Withdrawal Address screen, select the fund that you want to add the address to in **Source Fund**.
+8.  Choose the asset type in **Asset**.
+9.  Enter a name for the wallet in **Wallet Name**.
 
 :::note
 Ensure that the wallet name does not include spaces.
 :::
- 
-10. Type in the wallet address in **Wallet Address**.    
+
+10. Type in the wallet address in **Wallet Address**.
 11. Click **Continue**. See Authorise an Address (Trade Initiator) below.
 
 ### Authorise Address (Trade Initiator)
 
-1.  Tap the notification that you received on your phone. The Withdraw Address screen shows details of the transaction including fees.   
+1.  Tap the notification that you received on your phone. The Withdraw Address screen shows details of the transaction including fees.
 
 ![auth withdraw](/doc-images/AuthWith.png)
 
 *   name of the wallet address.
-*   the fund of the withdrawal address.   
-*   the name of the asset.    
-*   the name of the trade initiator.    
+*   the fund of the withdrawal address.
+*   the name of the asset.
+*   the name of the trade initiator.
 *   the expiry time and date of the request.
 
 You can also view other details of the withdrawal address including:
 
-*   the alphanumeric string of the address.   
-*   details of the trade initiator (including email address and alias).    
+*   the alphanumeric string of the address.
+*   details of the trade initiator (including email address and alias).
 *   the date in which the address creation was initiated.
 
-2.  To authorise, tap **Authorise**.    
+2.  To authorise, tap **Authorise**.
 3.  To reject, tap **Reject**.
 
 For the action you select, you then sign in with your biometric features and 6-digit PIN, and tap confirm on the confirmation screens.
@@ -140,19 +138,19 @@ You are also notified when a withdraw transaction is complete via an email.
 
 1.  Begin the task from in the Asset view or Ledger view.
 2.  Click the **New TX** button. The Select Type window shows.
-2.  Choose the **Withdraw** option in the Select Type box.   
+2.  Choose the **Withdraw** option in the Select Type box.
 3.  Click **Continue**. The Withdraw screen shows, and includes a scrollbar that lets you scroll down to other options.
 
 ![Withdraw main](/doc-images/withdrawmain.png)
 
-4.  In the From section, select the fund that you want to withdraw assets from in the **Fund** list.   
-5.  Choose the asset that you want to withdraw in the **Asset** list.    
-6.  Select the address that you want to send the money to in the **To** list.    
-7.  Enter the amount that you want to withdraw in **Amount**. The Blockchain Miner's fee and total withdrawal cost appears.   
-8.  Type in a reference number in **Reference**.    
-9.  To select a date for when the withdrawal takes place, click **Expires In** and enter days, hours, and minutes in the displayed fields.    
-10. To select a precise date for when the withdrawal takes place, click **Expires On** and enter a date and time in the displayed fields.    
-11. Click **Review Withdrawal**.    
+4.  In the From section, select the fund that you want to withdraw assets from in the **Fund** list.
+5.  Choose the asset that you want to withdraw in the **Asset** list.
+6.  Select the address that you want to send the money to in the **To** list.
+7.  Enter the amount that you want to withdraw in **Amount**. The Blockchain Miner's fee and total withdrawal cost appears.
+8.  Type in a reference number in **Reference**.
+9.  To select a date for when the withdrawal takes place, click **Expires In** and enter days, hours, and minutes in the displayed fields.
+10. To select a precise date for when the withdrawal takes place, click **Expires On** and enter a date and time in the displayed fields.
+11. Click **Review Withdrawal**.
 
 ### Review Withdrawal
 
@@ -162,10 +160,10 @@ In the **Review Withdrawal** screen, you can see details of the withdrawal trans
 
 These include:
 
-*   Asset and amount to withdraw    
-*   Source fund    
+*   Asset and amount to withdraw
+*   Source fund
 *   Transaction reference number
-*   Expiry date and time information    
+*   Expiry date and time information
 *   Blockchain miner's fee (see note)
 *   Total withdrawal cost (including the amount to withdraw and the miner's fee)
 *   Balance after the total withdrawal cost is deducted
@@ -174,13 +172,13 @@ These include:
      * Email address of the trade initiator
      * Network alias of the trade initiator
 *   To details:
-     * Withdraw wallet address   
+     * Withdraw wallet address
 
 :::info
 The Blockchain miner's fee is the reward paid to miners for the work and resources they need to generate blocks on the underlying network. You are presented with details of these fees when you add details of the transaction, and when you review it. While the miner's Blockchain fee is fixed for any withdrawal transaction, Qredo can periodically alter these fees.
 :::
 
-1. To start the withdrawal, click **Initiate Withdrawal**. You are then prompted to check your phone app.  
+1. To start the withdrawal, click **Initiate Withdrawal**. You are then prompted to check your phone app.
 2. To return to the previous screen, click **Back**.
 
 ### Authorise Withdrawal
@@ -191,7 +189,7 @@ Before authorising, you can view its details including the fees that are charged
 
 ![Authwith](/doc-images/authwithd.png)
 
-2.  To authorise, tap **Authorise**.   
+2.  To authorise, tap **Authorise**.
 3.  To reject, tap **Reject**.
 
 A withdrawal transaction can only be sent out of Qredo if it has met or has exceeded the threshold level for the number of custodian signatures. The threshold level is entered on the fund associated with the transaction.
@@ -205,22 +203,22 @@ You receive a notification as soon as the trade initiator has authorised the wit
 ![ApproveDetails](/doc-images/apprwith.png)
 
 *   type of asset and amount.
-*   the name linked to the recipient address.    
-*   the name of the trade initiator.   
-*   the transaction reference number.   
-*   the expiry date and time for approval.   
+*   the name linked to the recipient address.
+*   the name of the trade initiator.
+*   the transaction reference number.
+*   the expiry date and time for approval.
 
 You can also view other details linked to the transaction under the Show Details arrow including:
 
-*   the fund of the withdrawal.    
-*   the destination wallet name.    
-*   the alphanumeric string of the wallet address.   
-*   the name, email address, and network alias of the trade initiator.   
+*   the fund of the withdrawal.
+*   the destination wallet name.
+*   the alphanumeric string of the wallet address.
+*   the name, email address, and network alias of the trade initiator.
 *   details of the Qredo fee.
 
-1.  Tap the notification on your phone. The Withdrawal screen shows.    
+1.  Tap the notification on your phone. The Withdrawal screen shows.
 2.  Click **Show Details** to view more details of the transaction.
-3.  To approve, tap **Approve**.    
+3.  To approve, tap **Approve**.
 4.  To reject, tap **Reject**.
 
 For the action you select, you sign in with your biometric features and 6-digit passcode, and tap confirm in the confirmation screens.
@@ -242,22 +240,21 @@ These include details of:
 * [transaction approvals](#transaction-approvals) that cover those from the trade initiator and one or more custodians.
 * [custodian approvals](#custodian-approvals) specifically for the fund of the transaction.
 * [transactions in Ledger View](#transaction-view-ledger) for all funds under your account.
-* [progress details](#progress-details) in the form of a summary screen in both Approval and Ledger view. 
+* [progress details](#progress-details) in the form of a summary screen in both Approval and Ledger view.
 
-:::info 
+:::info
 Transactions in Ledger view includes both those that are pending, and those that have been written to the blockchain.
 :::
 
 ### Address Approvals
 
-1.  Click the **Addresses** tab,    
+1.  Click the **Addresses** tab,
 2.  Click the **Pending** or **Actioned** sub-tabs.
 
 The Pending sub tab shows these fields and pending approvals.
 
-|     |     |
+| Column | Description |
 | --- | --- |
-| **Column** | **Description** |
 | NAME | Name assigned to the address. |
 | FUND | Name of the fund. |
 | ASSET | Type of asset, e.g., Bitcoin. |
@@ -267,7 +264,7 @@ The Pending sub tab shows these fields and pending approvals.
 
 The actioned tab shows the same column fields. However, the ACTIONED column reflects the time and date in which the address approval was actioned. There are two states in the ACTIONED column. These include:
 
-*   APPROVED   
+*   APPROVED
 *   REJECTED
 
 The following is an example entry showing a pending approval with the status of APPROVED:
@@ -276,14 +273,13 @@ The following is an example entry showing a pending approval with the status of 
 
 ### Transaction Approvals
 
-1.  Click the **Transactions** tab,   
+1.  Click the **Transactions** tab,
 2.  Click the **Pending** or **Actioned** tabs.
 
 The pending tab shows these fields and pending approvals.
 
-|     |     |
+| Column | Description |
 | --- | --- |
-| **Column** | **Description** |
 | TYPE | Type of transaction. For a withdrawal, the column name shows as withdrawal. |
 | AMOUNT | The amount of the transaction and the type of asset. |
 | RECIPIENT | Recipient of the asset. For a withdrawal, the recipient is the name you assigned for that withdrawal. |
@@ -293,7 +289,7 @@ The pending tab shows these fields and pending approvals.
 
 The actioned tab shows the same column fields. However, the ACTIONED column reflects the time and date in which the transaction approval was actioned. There are two states in the ACTIONED column. These include:
 
-*   APPROVED   
+*   APPROVED
 *   REJECTED
 
 The following is an example actioned entry in the Approval view with the status of APPROVED:
@@ -302,14 +298,13 @@ The following is an example actioned entry in the Approval view with the status 
 
 ### Custodian Approvals
 
-1.  Click the **Custody** tab,    
+1.  Click the **Custody** tab,
 2.  Click the **Pending** or **Actioned** sub-tabs.
 
 The pending tab shows these fields and pending approvals.
 
-|     |     |
+| Column | Description |
 | --- | --- |
-| **Column** | **Description** |
 | ITEM | The transaction or withdrawal item. |
 | REQUESTED BY | The trade initiator that requested custodian approval. |
 | REQUESTED | The time and date in which the custodian approval was actioned. |
@@ -317,7 +312,7 @@ The pending tab shows these fields and pending approvals.
 
 The actioned tab shows the same column fields. However, the ACTIONED column reflects the time and date in which the custodian approval was actioned. There are two states in the ACTIONED column. These include:
 
-*   APPROVED   
+*   APPROVED
 *   REJECTED
 *   EXPIRED
 
@@ -335,9 +330,8 @@ The following is an example actioned entry in the Approval view with the status 
 
 TX Ledger shows the following details:
 
-|     |     |
+| Column | Description |
 | --- | --- |
-| **Column** | **Description** |
 | TYPE | Type of transaction. For a withdrawal, the column name shows as withdrawal. |
 | FUND | Name of the fund for the transaction.|
 | INITIATED | Trade initiator that started the transaction. |
@@ -363,7 +357,7 @@ For both the Approval and Ledger view, a summary screen shows details of the pro
 
 The following shows an example summary status of a completed withdrawal:
 
-![Withdraw Complete](/doc-images/Withconfirm.png) 
+![Withdraw Complete](/doc-images/Withconfirm.png)
 
 1. Click the Ledger or Approval view icon.
 2. In Approval view, access the Transaction or Custody tab and click the three buttons at the end of a table row.

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -5,11 +5,12 @@
  * work well for content-centric websites.
  */
 
- @import url('https://fonts.googleapis.com/css2?family=Barlow:wght@300;400;500;600;700&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Barlow:wght@300;400;500;600;700&display=swap");
 
 /* You can override the default Infima variables here. */
 :root {
-  --ifm-font-color-base: #454545;
+  --ifm-font-color-base: #191919;
+  --ifm-heading-color: #191919;
   --ifm-color-primary: #000000;
   --ifm-color-primary-dark: rgb(7, 7, 7);
   --ifm-color-primary-darker: rgb(31, 165, 136);
@@ -22,7 +23,7 @@
   --ifm-spacing-horizontal: 10px;
   --ifm-footer-background-color: #000000;
   --ifm-footer-title-color: #fff;
-  --ifm-footer-link-color: #B9B9B9;
+  --ifm-footer-link-color: #b9b9b9;
   --ifm-footer-link-hover-color: #fff;
   --ifm-footer-padding-vertical: 0;
   --ifm-footer-padding-horizontal: 0;
@@ -32,24 +33,26 @@
   --ifm-navbar-padding-vertical: 24px;
   --ifm-navbar-height: 91px;
   --ifm-global-radius: 8px;
-  --ifm-table-head-background: #FAFAFA;
-  --ifm-table-border-color: #EEEEEE;
+  --ifm-table-head-background: #191919;
+  --ifm-table-head-color: #fff;
+  --ifm-table-border-color: #b9b9b9;
   --ifm-table-head-font-weight: 500;
   --ifm-code-background: #eee;
   --ifm-code-color: #454545;
   --ifm-code-border-radius: 4px;
   --ifm-code-font-size: 16px;
+  --ifm-table-border-width: 1px;
 
   --ifm-color-success: #007955;
-  --ifm-color-info: #0086A4;
-  --ifm-color-warning: #806C00;
-  --ifm-color-danger: #DF001F;
+  --ifm-color-info: #0086a4;
+  --ifm-color-warning: #806c00;
+  --ifm-color-danger: #df001f;
 
-  --ifm-font-family-base: 'Barlow', sans-serif;
+  --ifm-font-family-base: "Barlow", sans-serif;
 }
 
 .markdown {
-  --ifm-link-color: #C30097;
+  --ifm-link-color: #c30097;
   --ifm-link-hover-color: #830164;
   --ifm-link-decoration: underline;
 }
@@ -80,54 +83,61 @@
 }
 
 .markdown h1 {
-  --ifm-h1-font-size: 58px;
-  --ifm-heading-font-weight: 500;
+  --ifm-h1-font-size: 54px;
+  --ifm-heading-font-weight: 600;
   --ifm-heading-line-height: 60px;
-  padding-bottom: 70px;
+  padding-top: 28px;
+  padding-bottom: 30px;
 }
 
 .markdown h2 {
-  --ifm-h2-font-size: 50px;
-  --ifm-heading-font-weight: 500;
-  --ifm-heading-line-height: 70px;
-  padding-bottom: 8px;
+  --ifm-h2-font-size: 38px;
+  --ifm-heading-font-weight: 400;
+  --ifm-heading-line-height: 46px;
+  padding-bottom: 6px;
+  padding-top: 28px;
 }
 
 .markdown h3 {
-  --ifm-h3-font-size: 28px;
-  --ifm-heading-font-weight: 200;
-  --ifm-heading-line-height: 32px;
-  padding-top: 20px;
-  padding-bottom: 8px;
+  --ifm-h3-font-size: 32px;
+  --ifm-heading-font-weight: 300;
+  --ifm-heading-line-height: 38px;
+  padding-top: 36px;
+  padding-bottom: 0;
 }
 
 .markdown h4 {
   --ifm-h4-font-size: 24px;
-  --ifm-heading-font-weight: 500;
+  --ifm-heading-font-weight: 600;
   --ifm-heading-line-height: 30px;
-  /* As this padding are set without reseting margin, it cannot be replaced by margin only. */
-  padding-top: 20px;
-  padding-bottom: 8px;
+  /* As this paddings are set without reseting margin, it cannot be replaced by margin only. */
+  padding-top: 30px;
+  padding-bottom: 0;
 }
 
 .markdown h5 {
-  --ifm-h5-font-size: 20px;
-  --ifm-heading-font-weight: 400;
-  --ifm-heading-line-height: 26px;
+  --ifm-h5-font-size: 18px;
+  --ifm-heading-font-weight: 500;
+  --ifm-heading-line-height: 24px;
   text-transform: uppercase;
 }
 
 .markdown p {
   font-size: 18px;
-  line-height: 26px;
+  line-height: 28px;
   color: var(--ifm-font-color-base);
 }
 
 .markdown img {
   border-radius: 8px;
   border: 1px solid #eee;
-  box-shadow: 0 4px 7px -1px rgba(38,8,8,0.15);
+  box-shadow: 0 4px 7px -1px rgba(38, 8, 8, 0.15);
   margin: 20px 0;
+}
+
+.markdown ol {
+  font-size: 18px;
+  line-height: 30px;
 }
 
 .markdown ul {
@@ -140,14 +150,19 @@
 
 .markdown ul li::before {
   content: "•";
-  color: #C30097;
+  color: #c30097;
   display: inline-block;
   width: 1em;
-  margin-left: -1em
+  margin-left: -1em;
 }
 
 .markdown ul li {
   padding-bottom: 4px;
+}
+
+.markdown table {
+  padding-top: 30px;
+  padding-bottom: 30px;
 }
 
 .markdown table tr {
@@ -159,9 +174,13 @@
   background-color: var(--ifm-table-head-background);
   color: var(--ifm-table-head-color);
   font-weight: var(--ifm-table-head-font-weight);
-  font-size: 14px;
+  font-size: 16px;
+  line-height: 24px;
   border: 0;
-  border-bottom: var(--ifm-table-border-width) solid var(--ifm-table-border-color);
+  height: 50px;
+  border-bottom: var(--ifm-table-border-width) solid
+    var(--ifm-table-border-color);
+  text-align: left;
 }
 
 .markdown table th + th {
@@ -172,6 +191,11 @@
   border: var(--ifm-table-border-width) solid var(--ifm-table-border-color);
   border: 0;
   padding: var(--ifm-table-cell-padding);
+  min-height: 50px;
+  background-color: #fff;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 24px;
 }
 
 .markdown table td + td {
@@ -179,7 +203,7 @@
 }
 
 .markdown table tr:last-child {
-  border-bottom: var(--ifm-table-border-width) solid var(--ifm-table-border-color);
+  border-bottom: 0;
 }
 
 .markdown code {
@@ -228,8 +252,8 @@
 }
 
 .alert {
-  background-color: #FBFBFB;
-  border: 1px solid #FAFAFA;
+  background-color: #fbfbfb;
+  border: 1px solid #fafafa;
   box-shadow: 0 4px 6px rgba(50, 50, 93, 0.11), 0 1px 3px rgba(0, 0, 0, 0.01);
   overflow: hidden;
   position: relative;
@@ -277,6 +301,10 @@
 
 .alert.alert--info .admonition-icon svg {
   fill: var(--ifm-color-info);
+}
+
+.admonition .admonition-info .alert .alert--info {
+  margin-bottom: 2em;
 }
 
 .alert.alert--warning::before {
@@ -332,20 +360,28 @@
 }
 
 .tabs__item--active {
-  border-bottom-color: #C30097;
+  border-bottom-color: #c30097;
 }
 
 /* SIDEBAR NAVIGATION */
 
 .menu__link {
-  font-size: 16px;
-  font-weight: 500;
+  font-size: 17px;
+  font-weight: 400;
 }
 
 .menu__link.menu__link--sublist {
-  font-size: 20px;
-  font-weight: 500;
+  font-size: 18px;
+  font-weight: 400;
   line-height: 26px;
   font-family: Barlow, sans-serif;
-  color: black;
+  color: #000;
+}
+
+.menu__link--sublist::after {
+  display: inline-block;
+  font-weight: 500;
+  background-size: 1.2rem 1.2rem;
+  height: 26px;
+  width: 26px;
 }


### PR DESCRIPTION
I updated the `docs/Deposit & Withdraw.md` to have place where we can see updated tables styles, but as tables in documentation ignores the table heads, the markdown files needs to be fixed. Not trying to fix it with styling in other places.

Updates https://qredo.atlassian.net/browse/QREDO-1055.

<img width="588" alt="Screenshot 2020-08-02 at 17 10 01" src="https://user-images.githubusercontent.com/2865988/89126052-01bc3e00-d4e3-11ea-98aa-2c3e9da0d51b.png">

