### PR TITLE
Fix background color for table header

### DIFF
--- a/src/css/redoc.css
+++ b/src/css/redoc.css
@@ -148,6 +148,10 @@
   background-color: #fff;
 }
 
+.redoc-wrap table tr th {
+  background-color: transparent;
+}
+
 .redoc-wrap table tr:nth-child(even) {
   background-color: #f9f9f9;
 }


### PR DESCRIPTION
### Short

\#\#\#\# Summary: Fix dark background for table header cells.


